### PR TITLE
add uploads to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*


### PR DESCRIPTION
# WHAT
.gitignoreにpublic/uploadsを追加
# WHY
大量に写真が追加される恐れがあり、gitの追跡対象から外すため。