### PR TITLE
チャット画面再修正

### DIFF
--- a/app/assets/stylesheets/modules/chat.scss
+++ b/app/assets/stylesheets/modules/chat.scss
@@ -21,6 +21,9 @@
       .member {
         display: inline-block;
         padding-right: 5px;
+        &__name {
+          padding-right: 5px;
+        }
         }
       }
     }


### PR DESCRIPTION
# what
チャット画面のメンバー表示(ヘッダー)の部分のスペースを空ける

# why
参加メンバー表示を見やすくするため。